### PR TITLE
Apply new design (#sp-4853)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ npm install @selfpub/react-ui-tree --save
 ```javascript
 <Tree
   paddingLeft={20}              // left padding for children nodes in pixels
+  hideRoot={true}               // rendering first root tree node
   tree={this.state.tree}        // tree object
   onChange={this.handleChange}  // onChange(tree) tree object changed
   renderNode={this.renderNode}  // renderNode(node) return react element
   renderCaret={this.renderCaret}  // renderCaret(node) return react element
+  renderDragIcon={this.renderDragIcon}  // renderDragIcon() return react element
 />
 
 // a sample tree object

--- a/example/DragIcon.js
+++ b/example/DragIcon.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+const DragIcon = () => {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g fill="#3B393E">
+        <path d="M4 0H8V4H4V0Z" />
+        <path d="M13 8H17V12H13V8Z" />
+        <path d="M13 16H17V20H13V16Z" />
+        <path d="M4 8H8V12H4V8Z" />
+        <path d="M4 16H8V20H4V16Z" />
+        <path d="M13 0H17V4H13V0Z" />
+      </g>
+    </svg>
+  );
+};
+
+export { DragIcon };

--- a/example/app.js
+++ b/example/app.js
@@ -22,7 +22,10 @@ import {
   Header,
   Buttons,
   Overlay,
+  DragIconContainer,
 } from "./styles";
+
+import { DragIcon } from "./DragIcon";
 
 class App extends Component {
   state = {
@@ -130,6 +133,14 @@ class App extends Component {
     return <Caret {...props} />;
   };
 
+  renderDragIcon = props => {
+    return (
+      <DragIconContainer {...props}>
+        <DragIcon />
+      </DragIconContainer>
+    );
+  };
+
   render() {
     const { dirty, tree, isEditing } = this.state;
 
@@ -156,13 +167,10 @@ class App extends Component {
               isNodeCollapsed={this.isNodeCollapsed}
               renderNode={this.renderNode}
               renderCaret={this.renderCaret}
+              renderDragIcon={this.renderDragIcon}
+              hideRoot={true}
             />
-            <Tree
-              tree={notes}
-              renderNode={this.renderNode}
-              renderCaret={this.renderCaret}
-              draggable={false}
-            />
+
           </Container>
         </Panel>
         <div className="inspector">

--- a/example/styles.js
+++ b/example/styles.js
@@ -64,16 +64,34 @@ export const Overlay = styled.div`
 
 export const Container = styled.div`
   text-align: left;
-  padding: 8px;
+  padding: 8px 16px 8px 8px;
   overflow-y: auto;
+`;
+
+export const DragIconContainer = styled.div`
+  position: absolute;
+  z-index: 1;
+  right: 0;
+  top: 0;
+  cursor: pointer;
+  height: 100%;
+
+  margin: auto;
+  text-align: center;
+  opacity: 0.1; 
+  transition: 1s;
+
+  :hover {
+    opacity: 1;
+  }
 `;
 
 export const Item = styled.div`
   display: block;
   text-decoration: none;
-  padding: 0 8px;
-  line-height: 2em;
-  height: 2em;
+  padding: 0 28px 0 8px;
+  line-height: 36px;
+  height: 36px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;

--- a/lib/node.js
+++ b/lib/node.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 
 import { Children, Inner, Node } from "./styles";
 
-export default class UITreeNode extends Component {
+class UITreeNode extends Component {
   innerRef = React.createRef();
 
   _onCollapse = e => {
@@ -42,6 +42,24 @@ export default class UITreeNode extends Component {
     }
 
     return null;
+  };
+
+  renderDrag = () => {
+    const {
+      index,
+      tree: { renderDragIcon },
+    } = this.props;
+
+    const { collapsed, nodrag } = index.node;
+
+    if (nodrag) {
+      return;
+    }
+
+    return renderDragIcon({
+      collapsed,
+      onMouseDown: this._onMouseDown,
+    });
   };
 
   renderChildren = () => {
@@ -84,17 +102,24 @@ export default class UITreeNode extends Component {
   };
 
   render() {
-    const { tree, index, dragging } = this.props;
+    const { tree, index, dragging, hideRoot = false } = this.props;
     const { node } = index;
+
+    if (hideRoot && index.id === 1) {
+      return this.renderChildren();
+    }
 
     return (
       <Node displayPlaceDrop={index.id === dragging}>
-        <Inner ref={this.innerRef} onMouseDown={this._onMouseDown}>
+        <Inner ref={this.innerRef}>
           {this.renderCollapse()}
           {tree.renderNode(node)}
+          {this.renderDrag()}
         </Inner>
         {node.collapsed ? null : this.renderChildren()}
       </Node>
     );
   }
 }
+
+export default UITreeNode;

--- a/lib/react-ui-tree.js
+++ b/lib/react-ui-tree.js
@@ -26,6 +26,7 @@ class UITree extends Component {
     tree.isNodeCollapsed = props.isNodeCollapsed;
     tree.renderNode = props.renderNode;
     tree.renderCaret = props.renderCaret;
+    tree.renderDragIcon = props.renderDragIcon;
 
     tree.changeNodeCollapsed = props.changeNodeCollapsed;
     tree.updateNodesPosition();
@@ -65,7 +66,7 @@ class UITree extends Component {
   };
 
   render() {
-    const { paddingLeft, draggable } = this.props;
+    const { paddingLeft, draggable, hideRoot = false } = this.props;
     const { tree, dragging } = this.state;
     const draggingDom = this.getDraggingDom();
 
@@ -80,6 +81,7 @@ class UITree extends Component {
           onDragStart={draggable && this.dragStart}
           onCollapse={this.toggleCollapse}
           dragging={dragging && dragging.id}
+          hideRoot={hideRoot}
         />
       </TreeContainer>
     );
@@ -123,7 +125,9 @@ class UITree extends Component {
       this._start = false;
     }
     const { tree, dragging } = this.state;
-    const { paddingLeft } = this.props;
+    const { paddingLeft, hideRoot } = this.props;
+
+    const direction = hideRoot ? 1 : -1;
 
     let newIndex = null;
     let index = tree.getIndex(dragging.id);
@@ -142,7 +146,8 @@ class UITree extends Component {
     dragging.y = pos.y;
 
     const diffX = dragging.x - paddingLeft / 2 - (index.left - 2) * paddingLeft;
-    const diffY = dragging.y - dragging.h / 2 - (index.top - 2) * dragging.h;
+    const diffY =
+      dragging.y + (direction * dragging.h) / 2 - (index.top - 2) * dragging.h;
 
     if (diffX < 0) {
       // left
@@ -256,12 +261,15 @@ UITree.propTypes = {
   paddingLeft: PropTypes.number,
   renderNode: PropTypes.func.isRequired,
   renderCaret: PropTypes.func.isRequired,
+  renderDragIcon: PropTypes.func.isRequired,
+
   draggable: PropTypes.bool,
 };
 
 UITree.defaultProps = {
   paddingLeft: 20,
   draggable: false,
+  hideRoot: false,
 };
 
 export default UITree;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -1,22 +1,23 @@
 import styled, { css } from "styled-components";
 
-export const TreeContainer = styled.div`
+const TreeContainer = styled.div`
   position: relative;
   overflow: hidden;
   user-select: none;
 `;
 
-export const Draggable = styled.div`
+const Draggable = styled.div`
   position: absolute;
   opacity: 0.8;
   user-select: none;
 `;
 
-export const Children = styled.div``;
+const Children = styled.div``;
 
-export const Node = styled.div(({ displayPlaceDrop }) =>
-     css`
-      border-width: 1px;
+const Node = styled.div(
+  ({ displayPlaceDrop }) =>
+    css`
+      border-width: ${displayPlaceDrop ? "1px" : "0"};
       border-style: dashed;
       border-color: ${displayPlaceDrop ? "rgba(0, 0, 0, 0.4)" : "transparent"};
 
@@ -26,9 +27,15 @@ export const Node = styled.div(({ displayPlaceDrop }) =>
     `
 );
 
-export const Inner = styled.div`
+const Inner = styled.div`
   position: relative;
   cursor: pointer;
-  padding-left: 10px;
-  color: #9da5b4;
 `;
+
+export {
+  TreeContainer,
+  Draggable,
+  Children,
+  Node,
+  Inner
+};

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.9.2",
     "js-tree": "^2.0.2",
     "prop-types": "^15.7.2",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.1.1"
   },
   "jest": {
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfpub/react-ui-tree",
-  "version": "4.2.2",
+  "version": "5.0.0",
   "description": "React tree component",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7032,10 +7032,10 @@ style-loader@^1.1.3:
     loader-utils "^1.2.3"
     schema-utils "^2.6.4"
 
-styled-components@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.0.tgz#2e3985b54f461027e1c91af3229e1c2530872a4e"
-  integrity sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==
+styled-components@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.1.tgz#96dfb02a8025794960863b9e8e365e3b6be5518d"
+  integrity sha512-1ps8ZAYu2Husx+Vz8D+MvXwEwvMwFv+hqqUwhNlDN5ybg6A+3xyW1ECrAgywhvXapNfXiz79jJyU0x22z0FFTg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"


### PR DESCRIPTION
It is necessary to add the ability to display a tree without a parent node.
Change the logic of grabbing the element for dragging (according to the layout).